### PR TITLE
Low-level logic to use hardlinks

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.18:
+  Allow to use hardlinks in copy_files and copy_files_with_regexp
 3.0.17:
   Fix --log option
 3.0.16:

--- a/biomaj_core/config.py
+++ b/biomaj_core/config.py
@@ -41,7 +41,8 @@ class BiomajConfig(object):
         'db.formats': '',
         'keep.old.version': 1,
         'docker.sudo': '1',
-        'auto_publish': 0
+        'auto_publish': 0,
+        'use_hardlinks': 0
     }
 
     # Old biomaj level compatibility

--- a/biomaj_core/utils.py
+++ b/biomaj_core/utils.py
@@ -257,7 +257,8 @@ class Utils(object):
                         if e.errno == errno.EPERM:
                             msg = "The FS at %s doesn't support hard links. Using regular copy."
                             logger.warn(msg, to_dir)
-                            # Copy this file
+                            # Copy this file (the stats are copied at the end
+                            # of the function)
                             shutil.copyfile(from_file, to_file)
                             # Don't try links anymore
                             use_hardlinks = False
@@ -345,15 +346,19 @@ class Utils(object):
                         if e.errno == errno.EPERM:
                             msg = "The FS at %s doesn't support hard links. Using regular copy."
                             logger.warn(msg, to_dir)
-                            # Copy this file
+                            # Copy this file (we copy the stats here because
+                            # it's not done at the end of the function)
                             shutil.copyfile(from_file, to_file)
+                            shutil.copystat(from_file, to_file)
                             # Don't try links anymore
                             use_hardlinks = False
                         if e.errno == errno.EXDEV:
                             msg = "Cross device hard link are impossible (source: %s, dest: %s). Using regular copy."
                             logger.warn(msg, from_file, to_dir)
-                            # Copy this file
+                            # Copy this file (we copy the stats here because
+                            # it's not done at the end of the function)
                             shutil.copyfile(from_file, to_file)
+                            shutil.copystat(from_file, to_file)
                             # Don't try links anymore
                             use_hardlinks = False
                         else:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ config = {
     'url': 'http://biomaj.genouest.org',
     'download_url': 'http://biomaj.genouest.org',
     'author_email': 'olivier.sallou@irisa.fr',
-    'version': '3.0.17',
+    'version': '3.0.18',
      'classifiers': [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/tests/global_hardlinks.properties
+++ b/tests/global_hardlinks.properties
@@ -1,0 +1,124 @@
+[GENERAL]
+test=1
+conf.dir=/tmp/biomaj/config
+log.dir=/tmp/biomaj/log
+process.dir=/tmp/biomaj/process
+#The root directory where all databases are stored.
+#If your data is not stored under one directory hirearchy
+#you can override this value in the database properties file.
+data.dir=/tmp/biomaj/
+lock.dir=/tmp/biomaj/lock
+cache.dir=/tmp/biomaj/cache
+use_hardlinks=1
+
+db.url=mongodb://localhost:27017
+db.name=biomaj_test
+
+use_ldap=1
+ldap.host=localhost
+ldap.port=389
+ldap.dn=nodomain
+
+# Use ElasticSearch for index/search capabilities
+use_elastic=0
+#Comma separated list of elasticsearch nodes  host1,host2:port2
+elastic_nodes=localhost
+elastic_index=biomaj_test
+
+celery.queue=biomaj
+celery.broker=mongodb://localhost:27017/biomaj_celery
+
+# Get directory stats (can be time consuming depending on number of files etc...)
+data.stats=1
+
+# List of user admin (linux user id, comma separated)
+admin=
+
+# Auto publish on updates (do not need publish flag, can be ovveriden in bank property file)
+auto_publish=0
+
+########################
+# Global properties file
+
+
+#To override these settings for a specific database go to its
+#properties file and uncomment or add the specific line you want
+#to override.
+
+#----------------
+# Mail Configuration
+#---------------
+#Uncomment thes lines if you want receive mail when the workflow is finished
+
+mail.smtp.host=
+mail.admin=
+mail.from=
+
+#---------------------
+#Proxy authentification
+#---------------------
+#proxyHost=
+#proxyPort=
+#proxyUser=
+#proxyPassword=
+
+#Number of thread for processes
+bank.num.threads=2
+
+#Number of threads to use for downloading
+files.num.threads=4
+
+#to keep more than one release increase this value
+keep.old.version=0
+
+#----------------------
+# Release configuration
+#----------------------
+release.separator=_
+
+#The historic log file is generated in log/
+#define level information for output : DEBUG,INFO,WARN,ERR
+historic.logfile.level=DEBUG
+
+#http.parse.dir.line=<a[\s]+href="([\S]+)/".*alt="\[DIR\]">.*([\d]{2}-[\w\d]{2,5}-[\d]{4}\s[\d]{2}:[\d]{2})
+http.parse.dir.line=<img[\s]+src="[\S]+"[\s]+alt="\[DIR\]"[\s]*/?>[\s]*<a[\s]+href="([\S]+)/"[\s]*>.*([\d]{2}-[\w\d]{2,5}-[\d]{4}\s[\d]{2}:[\d]{2})
+http.parse.file.line=<img[\s]+src="[\S]+"[\s]+alt="\[[\s]+\]"[\s]*/?>[\s]<a[\s]+href="([\S]+)".*([\d]{2}-[\w\d]{2,5}-[\d]{4}\s[\d]{2}:[\d]{2})[\s]+([\d\.]+[MKG]{0,1})
+
+http.group.dir.name=1
+http.group.dir.date=2
+http.group.file.name=1
+http.group.file.date=2
+http.group.file.size=3
+
+
+# Bank default access
+visibility.default=public
+
+
+[loggers]
+keys = root, biomaj
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_biomaj]
+level = DEBUG
+handlers = console
+qualname = biomaj
+propagate=0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = DEBUG
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s][%(threadName)s] %(message)s

--- a/tests/hardlinks.properties
+++ b/tests/hardlinks.properties
@@ -1,0 +1,43 @@
+[GENERAL]
+######################
+### Initialization ###
+
+db.fullname="local system bank test with hardlinks"
+db.name=local
+db.type=nucleic_protein
+
+offline.dir.name=offline/test/local_tmp
+dir.version=test/local
+
+frequency.update=0
+
+use_hardlinks=1
+
+### Synchronization ###
+
+files.num.threads=1
+
+# NCBI (download fasta)
+protocol=local
+server=
+
+release.file=
+release.regexp=
+release.file.compressed=
+
+remote.dir=/tmp/
+remote.files=^test.*
+
+#Uncomment if you don't want to extract the data files.
+#no.extract=true
+
+local.files=^test.*
+
+## Post Process  ##  The files should be located in the projectfiles/process directory
+
+db.post.process=
+
+
+### Deployment ###
+
+keep.old.version=1


### PR DESCRIPTION
This PR adds the low-level logic to use hardlinks in the configuration files and in low-level functions. By default, hardlinks are disabled so everything is backward-compatible.