### PR TITLE
Allow ftps and directftps protocols in configuration

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+3.0.19:
+  Add ftps and directftps protocols
 3.0.18:
   Allow to use hardlinks in copy_files and copy_files_with_regexp
 3.0.17:

--- a/biomaj_core/config.py
+++ b/biomaj_core/config.py
@@ -405,8 +405,8 @@ class BiomajConfig(object):
             status = False
         else:
             protocol = self.get('protocol')
-            allowed_protocols = ['none', 'multi', 'local', 'ftp', 'sftp', 'http',
-                                 'https', 'directftp', 'directhttp', 'directhttps', 'rsync', 'irods']
+            allowed_protocols = ['none', 'multi', 'local', 'ftp', 'ftps', 'http', 'https',
+                                 'directftp', 'directftps', 'directhttp', 'directhttps', 'rsync', 'irods']
             if protocol not in allowed_protocols:
                 logging.error('Protocol not supported: ' + protocol)
                 status = False
@@ -420,7 +420,7 @@ class BiomajConfig(object):
                 elif not self.get('remote.dir').endswith('/'):
                     logging.error('remote.dir must end with a /')
                     return False
-                if protocol not in ['direcftp', 'directhttp', 'directhttps'] and\
+                if protocol not in ['directftp', 'directftps', 'directhttp', 'directhttps'] and\
                         not self.get('remote.files') and\
                         not self.get('remote.list'):
                     logging.error('remote.files not set')

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ config = {
     'url': 'http://biomaj.genouest.org',
     'download_url': 'http://biomaj.genouest.org',
     'author_email': 'olivier.sallou@irisa.fr',
-    'version': '3.0.18',
+    'version': '3.0.19',
      'classifiers': [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
This PR is a follow-up of genouest/biomaj-download#12 to allow `ftps` and `directftps` protocols in bank configuration files.