### PR TITLE
Harden hardlinks

### DIFF
--- a/biomaj_core/utils.py
+++ b/biomaj_core/utils.py
@@ -271,7 +271,7 @@ class Utils(object):
                             # Don't try links anymore
                             use_hardlinks = False
                         elif e.errno == errno.EXDEV:
-                            msg = "Cross device hard link are impossible (source: %s, dest: %s). Using regular copy."
+                            msg = "Cross device hard link is impossible (source: %s, dest: %s). Using regular copy."
                             logger.warn(msg, from_file, to_dir)
                             # Copy this file
                             shutil.copyfile(from_file, to_file)
@@ -369,7 +369,7 @@ class Utils(object):
                             # Don't try links anymore
                             use_hardlinks = False
                         elif e.errno == errno.EXDEV:
-                            msg = "Cross device hard link are impossible (source: %s, dest: %s). Using regular copy."
+                            msg = "Cross device hard link is impossible (source: %s, dest: %s). Using regular copy."
                             logger.warn(msg, from_file, to_dir)
                             # Copy this file (we copy the stats here because
                             # it's not done at the end of the function)

--- a/biomaj_core/utils.py
+++ b/biomaj_core/utils.py
@@ -254,7 +254,15 @@ class Utils(object):
                         logger.debug("Using hardlinks to copy %s",
                                      file_to_copy['name'])
                     except OSError as e:
-                        if e.errno == errno.EPERM:
+                        if e.errno in (errno.ENOSYS, errno.ENOTSUP):
+                            msg = "Your system doesn't support hard links. Using regular copy."
+                            logger.warn(msg)
+                            # Copy this file (the stats are copied at the end
+                            # of the function)
+                            shutil.copyfile(from_file, to_file)
+                            # Don't try links anymore
+                            use_hardlinks = False
+                        elif e.errno == errno.EPERM:
                             msg = "The FS at %s doesn't support hard links. Using regular copy."
                             logger.warn(msg, to_dir)
                             # Copy this file (the stats are copied at the end
@@ -262,7 +270,7 @@ class Utils(object):
                             shutil.copyfile(from_file, to_file)
                             # Don't try links anymore
                             use_hardlinks = False
-                        if e.errno == errno.EXDEV:
+                        elif e.errno == errno.EXDEV:
                             msg = "Cross device hard link are impossible (source: %s, dest: %s). Using regular copy."
                             logger.warn(msg, from_file, to_dir)
                             # Copy this file
@@ -343,7 +351,15 @@ class Utils(object):
                         logger.debug("Using hardlinks to copy %s",
                                      file_to_copy['name'])
                     except OSError as e:
-                        if e.errno == errno.EPERM:
+                        if e.errno in (errno.ENOSYS, errno.ENOTSUP):
+                            msg = "Your system doesn't support hard links. Using regular copy."
+                            logger.warn(msg)
+                            # Copy this file (the stats are copied at the end
+                            # of the function)
+                            shutil.copyfile(from_file, to_file)
+                            # Don't try links anymore
+                            use_hardlinks = False
+                        elif e.errno == errno.EPERM:
                             msg = "The FS at %s doesn't support hard links. Using regular copy."
                             logger.warn(msg, to_dir)
                             # Copy this file (we copy the stats here because
@@ -352,7 +368,7 @@ class Utils(object):
                             shutil.copystat(from_file, to_file)
                             # Don't try links anymore
                             use_hardlinks = False
-                        if e.errno == errno.EXDEV:
+                        elif e.errno == errno.EXDEV:
                             msg = "Cross device hard link are impossible (source: %s, dest: %s). Using regular copy."
                             logger.warn(msg, from_file, to_dir)
                             # Copy this file (we copy the stats here because


### PR DESCRIPTION
We have noticed that some systems return `ENOSYS` when hard links are not implemented (this is the case for `sshfs`). In the previous implementation, this would lead to failure. This PR handles this case (and also the related `ENOTSUP`) by reverting to regular copy.

By the way, we have noticed a logic error when checking those exceptions. This PR also corrects that. 