### PR TITLE
 Add default values for ssh key handling

### DIFF
--- a/biomaj_core/config.py
+++ b/biomaj_core/config.py
@@ -47,7 +47,7 @@ class BiomajConfig(object):
         'use_hardlinks': 0,
         'wait_policy': 'wait_fixed(3)',
         'stop_condition': 'stop_after_attempt(3)',
-        'ssh_hosts_file': '/tmp/known_hosts',
+        'ssh_hosts_file': os.path.expanduser('~/.ssh/known_hosts'),
         'ssh_new_host': 'reject',
     }
 

--- a/biomaj_core/config.py
+++ b/biomaj_core/config.py
@@ -46,7 +46,9 @@ class BiomajConfig(object):
         'auto_publish': 0,
         'use_hardlinks': 0,
         'wait_policy': 'wait_fixed(3)',
-        'stop_condition': 'stop_after_attempt(3)'
+        'stop_condition': 'stop_after_attempt(3)',
+        'ssh_hosts_file': '/tmp/known_hosts',
+        'ssh_new_host': 'reject',
     }
 
     # Old biomaj level compatibility


### PR DESCRIPTION
This PR add default values for the mechanism introduced in genouest/biomaj-download#26 to handle ssh keys.