### PR TITLE
remove ref. to extraneous & deprecated 'mock'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pytest
-mock
 elasticsearch==5.5.3
 requests

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ config = {
                          'elasticsearch',
                          'requests'
                         ],
-    'tests_require': ['pytest', 'mock'],
+    'tests_require': ['pytest'],
     'packages': find_packages(),
     'include_package_data': True,
     'name': 'biomaj_core'


### PR DESCRIPTION
'mock' is now part of the standard library under the name 'unittest.mock'